### PR TITLE
Add Apple login screen and navigation

### DIFF
--- a/lib/apple_login_screen.dart
+++ b/lib/apple_login_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class AppleLoginScreen extends StatelessWidget {
+  const AppleLoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Mit Apple ID anmelden'),
+      ),
+      body: const Center(
+        child: Text('Apple-ID-Anmeldung folgt...'),
+      ),
+    );
+  }
+}

--- a/lib/login_screen.dart
+++ b/lib/login_screen.dart
@@ -53,6 +53,9 @@ class LoginScreen extends StatelessWidget {
                   icon: Icons.apple,
                   bgColor: Colors.white,
                   textColor: Colors.black,
+                  onPressed: () {
+                    Navigator.pushNamed(context, '/appleLogin');
+                  },
                 ),
 
                 const SizedBox(height: 16),
@@ -62,8 +65,9 @@ class LoginScreen extends StatelessWidget {
                   context: context,
                   label: 'Mit Facebook anmelden',
                   icon: Icons.facebook,
-                  bgColor: Color(0xFF1877F2),
+                  bgColor: const Color(0xFF1877F2),
                   textColor: Colors.white,
+                  onPressed: () {},
                 ),
 
                 const SizedBox(height: 16),
@@ -75,6 +79,9 @@ class LoginScreen extends StatelessWidget {
                   icon: Icons.phone,
                   bgColor: Colors.white,
                   textColor: Colors.black,
+                  onPressed: () {
+                    Navigator.pushNamed(context, '/phoneLogin');
+                  },
                 ),
 
                 const Spacer(),
@@ -108,6 +115,7 @@ class LoginScreen extends StatelessWidget {
     required IconData icon,
     required Color bgColor,
     required Color textColor,
+    required VoidCallback onPressed,
   }) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 32),
@@ -115,9 +123,7 @@ class LoginScreen extends StatelessWidget {
         width: double.infinity,
         height: 50,
         child: ElevatedButton.icon(
-          onPressed: () {
-          Navigator.pushReplacementNamed(context, '/'); // Hier kannst du Navigation oder Login-Logik einfügen
-          },
+          onPressed: onPressed,
           icon: Icon(icon, color: textColor),
           label: Text(
             label,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'home_screen.dart';
 import 'register_screen.dart';
 import 'profile_screen.dart';
 import 'phone_login_screen.dart';
+import 'apple_login_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -21,10 +22,11 @@ class MyApp extends StatelessWidget {
       home: const WelcomeScreen(),
       routes: {
         '/login':(context) => const LoginScreen(),
-        '/register':(context) => const RegisterScreen(),   
+        '/register':(context) => const RegisterScreen(),
         '/home': (context) => const HomeScreen(),
         '/profile': (context) => const ProfileScreen(),
-        '/phoneLogin' : (context) => const PhoneLoginScreen(), 
+        '/phoneLogin' : (context) => const PhoneLoginScreen(),
+        '/appleLogin': (context) => const AppleLoginScreen(),
      },
     );
   }


### PR DESCRIPTION
## Summary
- add placeholder Apple login screen
- wire Apple login button to the new screen and tweak helper button callback
- register new Apple login route in main app

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c56b3e02608326bc31ebd8e5d9d99f